### PR TITLE
Corrección al login.

### DIFF
--- a/Svelte/src/Login.svelte
+++ b/Svelte/src/Login.svelte
@@ -25,7 +25,7 @@
         var resp = await fetch(getLoginURL);
         userId = await resp.json();
         //getlistadoUsuarios();
-            if (userId.nick===userId){
+            if (userId!=="false"){
                 seccion = "entrada";
             }else{
                 alert('Algo ha salido mal. Vuelve a intentarlo.');


### PR DESCRIPTION
No entiendo la comparación entre UserID.nick y UserID. Por lo que he visto, al hacer un logoin correcto UserID recibe un string con el _id de mongo del usuario. Cuando el login es incorrecto, recibe el string "false", así que propongo considerar como correcto cuanquier login que entregue un string diferente a "falso".